### PR TITLE
Typo

### DIFF
--- a/public/test3.html
+++ b/public/test3.html
@@ -16,7 +16,7 @@
         <h1>🏛️ Test 3</h1>
         <p>Embedding <span>twitter.com-2020-09-03.wacz</span> coming from <span>warcembed-demo.s3.amazonaws.com</span>, proxied via <span>warc-embed.lil.tools</span>.</p>
         <p>This should be safe and work even if third-party cookies are blocked.</p>
-        <p><span>permafact-demo.s3.amazonaws.com</span> supports range requests, the proxy passes range headers along.</p>
+        <p><span>warcembed-demo.s3.amazonaws.com</span> supports range requests, the proxy passes range headers along.</p>
         <p><a href="/">👈  Back to the index</a></p>
       </div>
     </header>


### PR DESCRIPTION
`test3.html` was still referencing `permafact-demo.s3.amazonaws.com`